### PR TITLE
fix content scrolling

### DIFF
--- a/assets/sass/modules/body.scss
+++ b/assets/sass/modules/body.scss
@@ -3,10 +3,23 @@ body {
 }
 
 .content {
+    padding-left: 13%;
+    padding-right: 13%;
     padding-top: 1rem;
     a {
 	text-decoration: underline;
 	background-color: transparent;
+    }
+}
+
+@include media-breakpoint-up(md) {
+    .content {
+	top: 4rem;
+	display: block;
+	position: sticky;
+	max-height: calc(100vh - 4em);
+	overflow-y: auto;
+	z-index: 1000;
     }
 }
 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -17,11 +17,11 @@
 		<nav class="navigation col-sm-12 order-sm-12 col-md-3 order-md-1">
 		    {{ partial "nav.html" . }}
 		</nav>
-		<div class="content col-sm-12 order-sm-1 col-md-6 mx-md-auto order-md-12">
+		<div class="content col-sm-12 order-sm-1 col-md-9 mx-md-auto order-md-12">
 		    {{ block "main" .}}
 		    <!-- This is where the page content redners -->
 		    {{ end }}
-		</div>
+      </div>
 	    </div>
 
             <!-- {{ partial "page-footer.html" . }} -->


### PR DESCRIPTION
prevents scroll bar of content pane from extending over the top header bar

Before
![Screenshot_2020-11-29_00-49-28](https://user-images.githubusercontent.com/9555491/100529201-cc97d200-31dc-11eb-8292-c465138f8ec0.png)

After
![Screenshot_2020-11-29_00-49-06](https://user-images.githubusercontent.com/9555491/100529202-d02b5900-31dc-11eb-90de-5a8470d0c33b.png)
